### PR TITLE
Bugfix for cases where message conversion fails due to missing aerodrome

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.8.9</version>

--- a/src/main/java/fi/fmi/avi/converter/tac/AbstractTACParser.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/AbstractTACParser.java
@@ -291,8 +291,8 @@ public abstract class AbstractTACParser<T extends AviationWeatherMessageOrCollec
     protected boolean checkAndReportLexingResult(final LexemeSequence lexed, final ConversionHints hints, final ConversionResult<?> result) {
         if (!lexingSuccessful(lexed, hints)) {
             ConversionIssue.Severity severity = ConversionIssue.Severity.ERROR;
-            if (hints != null && hints.containsValue(ConversionHints.VALUE_PARSING_MODE_ALLOW_SYNTAX_ERRORS)
-                    || hints.containsValue(ConversionHints.VALUE_PARSING_MODE_ALLOW_ANY_ERRORS)) {
+            if (hints != null && (hints.containsValue(ConversionHints.VALUE_PARSING_MODE_ALLOW_SYNTAX_ERRORS) //
+                    || hints.containsValue(ConversionHints.VALUE_PARSING_MODE_ALLOW_ANY_ERRORS))) {
                 severity = ConversionIssue.Severity.WARNING;
             } else {
                 result.addIssue(new ConversionIssue(ConversionIssue.Type.SYNTAX, "Input message lexing was not fully successful: " + lexed));

--- a/src/main/java/fi/fmi/avi/converter/tac/taf/TAFTACParserBase.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/taf/TAFTACParserBase.java
@@ -112,8 +112,9 @@ public abstract class TAFTACParserBase<T extends TAF> extends AbstractTACParser<
             }
         });
 
+        final AtomicBoolean hasAerodrome = new AtomicBoolean(false);
         lexed.getFirstLexeme().findNext(LexemeIdentity.AERODROME_DESIGNATOR, (match) -> {
-            final LexemeIdentity[] before = new LexemeIdentity[] {LexemeIdentity.ISSUE_TIME, LexemeIdentity.NIL, LexemeIdentity.VALID_TIME,
+            final LexemeIdentity[] before = new LexemeIdentity[] { LexemeIdentity.ISSUE_TIME, LexemeIdentity.NIL, LexemeIdentity.VALID_TIME,
                     LexemeIdentity.CANCELLATION, LexemeIdentity.SURFACE_WIND, LexemeIdentity.HORIZONTAL_VISIBILITY, LexemeIdentity.WEATHER,
                     LexemeIdentity.CLOUD, LexemeIdentity.CAVOK, LexemeIdentity.MIN_TEMPERATURE, LexemeIdentity.MAX_TEMPERATURE,
                     LexemeIdentity.TAF_FORECAST_CHANGE_INDICATOR, LexemeIdentity.REMARKS_START };
@@ -122,8 +123,14 @@ public abstract class TAFTACParserBase<T extends TAF> extends AbstractTACParser<
                 result.addIssue(issue);
             } else {
                 builder.setAerodrome(AerodromeImpl.builder().setDesignator(match.getParsedValue(Lexeme.ParsedValueName.VALUE, String.class)).build());
+                hasAerodrome.set(true);
             }
         }, () -> result.addIssue(new ConversionIssue(ConversionIssue.Type.SYNTAX, "Aerodrome designator not given in " + input)));
+
+        // End processing if the message has no aerodrome
+        if (!hasAerodrome.get()) {
+            return result;
+        }
 
         result.addIssue(setTAFIssueTime(builder, lexed, hints));
 

--- a/src/main/java/fi/fmi/avi/converter/tac/taf/TAFTACParserBase.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/taf/TAFTACParserBase.java
@@ -3,6 +3,7 @@ package fi.fmi.avi.converter.tac.taf;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import fi.fmi.avi.converter.ConversionHints;

--- a/src/main/java/fi/fmi/avi/converter/tac/taf/TAFTACParserBase.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/taf/TAFTACParserBase.java
@@ -128,11 +128,6 @@ public abstract class TAFTACParserBase<T extends TAF> extends AbstractTACParser<
             }
         }, () -> result.addIssue(new ConversionIssue(ConversionIssue.Type.SYNTAX, "Aerodrome designator not given in " + input)));
 
-        // End processing if the message has no aerodrome
-        if (!hasAerodrome.get()) {
-            return result;
-        }
-
         result.addIssue(setTAFIssueTime(builder, lexed, hints));
 
         lexed.getFirstLexeme().findNext(LexemeIdentity.NIL,  (match) -> {
@@ -241,6 +236,11 @@ public abstract class TAFTACParserBase<T extends TAF> extends AbstractTACParser<
         }
 
         result.addIssue(setFromChangeForecastEndTimes(builder));
+
+        // End processing if the message has no aerodrome
+        if (!hasAerodrome.get()) {
+            return result;
+        }
 
         result.setConvertedMessage(builder.build());
         return result;

--- a/src/test/java/fi/fmi/avi/converter/tac/metar/InvalidAerodromeTest.java
+++ b/src/test/java/fi/fmi/avi/converter/tac/metar/InvalidAerodromeTest.java
@@ -1,0 +1,59 @@
+package fi.fmi.avi.converter.tac.metar;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import fi.fmi.avi.converter.AviMessageConverter;
+import fi.fmi.avi.converter.ConversionHints;
+import fi.fmi.avi.converter.ConversionResult;
+import fi.fmi.avi.converter.tac.TACTestConfiguration;
+import fi.fmi.avi.converter.tac.conf.TACConverter;
+import fi.fmi.avi.model.metar.METAR;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TACTestConfiguration.class, loader = AnnotationConfigContextLoader.class)
+public class InvalidAerodromeTest {
+
+    @Autowired
+    private AviMessageConverter converter;
+
+    @Test
+    public void invalidAerodromeWithSyntaxErrorsAllowed() {
+        final ConversionHints hints = new ConversionHints();
+        hints.put(ConversionHints.KEY_PARSING_MODE, ConversionHints.VALUE_PARSING_MODE_ALLOW_SYNTAX_ERRORS);
+        ConversionResult<METAR> result = this.converter.convertMessage("METAR EF 011350Z AUTO VRB02KT CAVOK 22/12 Q1008=", TACConverter.TAC_TO_METAR_POJO,
+                hints);
+        assertEquals(ConversionResult.Status.FAIL, result.getStatus());
+        assertFalse(result.getConvertedMessage().isPresent());
+        assertThat(result.getConversionIssues()).anySatisfy(issue -> assertThat(issue.getMessage()).startsWith("Aerodrome designator not given in"));
+    }
+
+    @Test
+    public void invalidAerodromeWithAnyErrorsAllowed() {
+        final ConversionHints hints = new ConversionHints();
+        hints.put(ConversionHints.KEY_PARSING_MODE, ConversionHints.VALUE_PARSING_MODE_ALLOW_ANY_ERRORS);
+        ConversionResult<METAR> result = this.converter.convertMessage("METAR EF 011350Z AUTO VRB02KT CAVOK 22/12 Q1008=", TACConverter.TAC_TO_METAR_POJO,
+                hints);
+        assertEquals(ConversionResult.Status.FAIL, result.getStatus());
+        assertFalse(result.getConvertedMessage().isPresent());
+        assertThat(result.getConversionIssues()).anySatisfy(issue -> assertThat(issue.getMessage()).startsWith("Aerodrome designator not given in"));
+    }
+
+    @Test
+    public void invalidAerodromeWithStrictParsing() {
+        ConversionResult<METAR> result = this.converter.convertMessage("METAR EF 011350Z AUTO VRB02KT CAVOK 22/12 Q1008=", TACConverter.TAC_TO_METAR_POJO);
+        assertEquals(ConversionResult.Status.FAIL, result.getStatus());
+        assertFalse(result.getConvertedMessage().isPresent());
+        assertThat(result.getConversionIssues()).anySatisfy(
+                issue -> assertThat(issue.getMessage()).startsWith("Input message lexing was not fully successful"));
+    }
+
+}

--- a/src/test/java/fi/fmi/avi/converter/tac/taf/InvalidAerodromeTest.java
+++ b/src/test/java/fi/fmi/avi/converter/tac/taf/InvalidAerodromeTest.java
@@ -1,0 +1,58 @@
+package fi.fmi.avi.converter.tac.taf;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import fi.fmi.avi.converter.AviMessageConverter;
+import fi.fmi.avi.converter.ConversionHints;
+import fi.fmi.avi.converter.ConversionResult;
+import fi.fmi.avi.converter.tac.TACTestConfiguration;
+import fi.fmi.avi.converter.tac.conf.TACConverter;
+import fi.fmi.avi.model.taf.TAF;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TACTestConfiguration.class, loader = AnnotationConfigContextLoader.class)
+
+public class InvalidAerodromeTest {
+
+    @Autowired
+    private AviMessageConverter converter;
+
+    @Test
+    public void invalidAerodromeWithSyntaxErrorsAllowed() {
+        final ConversionHints hints = new ConversionHints();
+        hints.put(ConversionHints.KEY_PARSING_MODE, ConversionHints.VALUE_PARSING_MODE_ALLOW_SYNTAX_ERRORS);
+        ConversionResult<TAF> result = this.converter.convertMessage("TAF EF 150935Z 1512/1524 00000KT CAVOK=", TACConverter.TAC_TO_TAF_POJO, hints);
+        assertEquals(ConversionResult.Status.FAIL, result.getStatus());
+        assertFalse(result.getConvertedMessage().isPresent());
+        assertThat(result.getConversionIssues()).anySatisfy(issue -> assertThat(issue.getMessage()).startsWith("Aerodrome designator not given in"));
+    }
+
+    @Test
+    public void invalidAerodromeWithAnyErrorsAllowed() {
+        final ConversionHints hints = new ConversionHints();
+        hints.put(ConversionHints.KEY_PARSING_MODE, ConversionHints.VALUE_PARSING_MODE_ALLOW_ANY_ERRORS);
+        ConversionResult<TAF> result = this.converter.convertMessage("TAF EF 150935Z 1512/1524 00000KT CAVOK=", TACConverter.TAC_TO_TAF_POJO, hints);
+        assertEquals(ConversionResult.Status.FAIL, result.getStatus());
+        assertFalse(result.getConvertedMessage().isPresent());
+        assertThat(result.getConversionIssues()).anySatisfy(issue -> assertThat(issue.getMessage()).startsWith("Aerodrome designator not given in"));
+    }
+
+    @Test
+    public void invalidAerodromeWithStrictParsing() {
+        ConversionResult<TAF> result = this.converter.convertMessage("TAF EF 150935Z 1512/1524 00000KT CAVOK=", TACConverter.TAC_TO_TAF_POJO);
+        assertEquals(ConversionResult.Status.FAIL, result.getStatus());
+        assertFalse(result.getConvertedMessage().isPresent());
+        assertThat(result.getConversionIssues()).anySatisfy(
+                issue -> assertThat(issue.getMessage()).startsWith("Input message lexing was not fully successful"));
+    }
+
+}


### PR DESCRIPTION
The bug manifests when:
- the aerodrome lexeme is malformed/missing
- syntax or any errors are allowed through conversion hints

This fix stops the conversion just before the aerodrome message is built. The other option would be to short circuit the conversion after we know that the message cannot be built due to missing aerodrome, but then the conversion result wouldn't show other conversion issues that arise later on in the conversion.