### PR TITLE
Fmi avi messageconverter tac 102

### DIFF
--- a/src/main/java/fi/fmi/avi/converter/tac/bulletin/AbstractTACBulletinSerializer.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/bulletin/AbstractTACBulletinSerializer.java
@@ -52,8 +52,6 @@ public abstract class AbstractTACBulletinSerializer<S extends AviationWeatherMes
         final T input = accepts(msg);
         final LexemeSequenceBuilder retval = this.getLexingFactory().createLexemeSequenceBuilder();
         final ReconstructorContext<T> baseCtx = new ReconstructorContext<>(input, hints);
-        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN, 2);
-        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
         appendToken(retval, LexemeIdentity.BULLETIN_HEADING_DATA_DESIGNATORS, input, getBulletinClass(), baseCtx);
         appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
         appendToken(retval, LexemeIdentity.BULLETIN_HEADING_LOCATION_INDICATOR, input, getBulletinClass(), baseCtx);

--- a/src/test/java/fi/fmi/avi/converter/tac/bulletin/GenericMeteorologicalBulletinTACSerializerTest.java
+++ b/src/test/java/fi/fmi/avi/converter/tac/bulletin/GenericMeteorologicalBulletinTACSerializerTest.java
@@ -47,8 +47,7 @@ public class GenericMeteorologicalBulletinTACSerializerTest {
         final Optional<String> tacBulletin = tacResult.getConvertedMessage();
         assertTrue(tacBulletin.isPresent());
         TestCase.assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "UXFI81 EFKL 271402"//
+                "UXFI81 EFKL 271402"//
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()
                         + "LOW WIND EFHK 270925Z 1000FT 2000FT FL050 FL100 200/05" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "     260/05 310/05 320/15=", tacBulletin.get());
@@ -64,8 +63,7 @@ public class GenericMeteorologicalBulletinTACSerializerTest {
         final Optional<String> tacBulletin = tacResult.getConvertedMessage();
         assertTrue(tacBulletin.isPresent());
         TestCase.assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "UXFI81 EFKL 271402"//
+                "UXFI81 EFKL 271402"//
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "LOW WIND EFHK 270925Z" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
@@ -83,8 +81,7 @@ public class GenericMeteorologicalBulletinTACSerializerTest {
         final Optional<String> tacBulletin = tacResult.getConvertedMessage();
         assertTrue(tacBulletin.isPresent());
         TestCase.assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "UXFI81 EFKL 271402"//
+                "UXFI81 EFKL 271402"//
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "LOW WIND EFHK 270925Z" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
@@ -102,8 +99,7 @@ public class GenericMeteorologicalBulletinTACSerializerTest {
         final Optional<String> tacBulletin = tacResult.getConvertedMessage();
         assertTrue(tacBulletin.isPresent());
         TestCase.assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "UXFI81 EFKL 271402"//
+                "UXFI81 EFKL 271402"//
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "LOW WIND EFHK 270925Z" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
@@ -121,8 +117,7 @@ public class GenericMeteorologicalBulletinTACSerializerTest {
         final Optional<String> tacBulletin = tacResult.getConvertedMessage();
         assertTrue(tacBulletin.isPresent());
         TestCase.assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "UXFI81 EFKL 271402"//
+                "UXFI81 EFKL 271402"//
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "LOW WIND EFHK 270925Z" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//

--- a/src/test/java/fi/fmi/avi/converter/tac/sigmet/SIGMETBulletinTACSerializationTest.java
+++ b/src/test/java/fi/fmi/avi/converter/tac/sigmet/SIGMETBulletinTACSerializationTest.java
@@ -65,8 +65,7 @@ public class SIGMETBulletinTACSerializationTest {
         assertTrue(tacBulletin.isPresent());
         //NOTE: the line wrapping does not not work as expected here due to the fact that 'N6008\nE02628' is parsed as a single token
         TestCase.assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "WSFI31 EFKL 170700"//
+                        "WSFI31 EFKL 170700"//
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()
                         + "EFIN SIGMET 1 VALID 170750/170950 EFKL- EFIN FINLAND FIR" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "     SEV TURB FCST AT 0740Z S OF LINE N5953 E01931 -" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//

--- a/src/test/java/fi/fmi/avi/converter/tac/swx/SWXBulletinTACSerializationTest.java
+++ b/src/test/java/fi/fmi/avi/converter/tac/swx/SWXBulletinTACSerializationTest.java
@@ -70,8 +70,7 @@ public class SWXBulletinTACSerializationTest {
         assertTrue(stringResult.getConversionIssues().isEmpty());
         assertTrue(stringResult.getConvertedMessage().isPresent());
         assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "FNXX01 EFKL 020500"//
+                        "FNXX01 EFKL 020500"//
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "SWX ADVISORY" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "STATUS:             TEST" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//

--- a/src/test/java/fi/fmi/avi/converter/tac/taf/TAFBulletinTACSerializationTest.java
+++ b/src/test/java/fi/fmi/avi/converter/tac/taf/TAFBulletinTACSerializationTest.java
@@ -59,8 +59,7 @@ public class TAFBulletinTACSerializationTest {
         assertTrue(stringResult.getConversionIssues().isEmpty());
         assertTrue(stringResult.getConvertedMessage().isPresent());
         assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "FCFI33 EFPP 020500 AAA"//
+                "FCFI33 EFPP 020500 AAA"//
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "TAF AMD EFKE 020532Z 0206/0215 05005KT 9999 -SHRA BKN004" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "     BECMG 0206/0208 FEW005 BKN020 TEMPO 0206/0215 4000" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
@@ -94,8 +93,7 @@ public class TAFBulletinTACSerializationTest {
         assertTrue(stringResult.getConversionIssues().isEmpty());
         assertTrue(stringResult.getConvertedMessage().isPresent());
         assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "FCFI33 EFPP 020500 RRZ" //
+                        "FCFI33 EFPP 020500 RRZ" //
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "TAF EFKE 020532Z 0206/0215 05005KT 9999 -SHRA BKN004 BECMG" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "     0206/0208 FEW005 BKN020 TEMPO 0206/0215 4000 SHRA" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
@@ -153,8 +151,7 @@ public class TAFBulletinTACSerializationTest {
         assertTrue(stringResult.getConversionIssues().isEmpty());
         assertTrue(stringResult.getConvertedMessage().isPresent());
         assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "FCFI33 EFPP 020500 CCB"//
+                "FCFI33 EFPP 020500 CCB"//
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "TAF COR EFKE 020532Z 0206/0215 05005KT 9999 -SHRA BKN004" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "     BECMG 0206/0208 FEW005 BKN020 TEMPO 0206/0215 4000" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
@@ -187,8 +184,7 @@ public class TAFBulletinTACSerializationTest {
         final Optional<String> tacBulletin = tacResult.getConvertedMessage();
         assertTrue(tacBulletin.isPresent());
         assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "FCFI33 EFPP 020500"//
+                "FCFI33 EFPP 020500"//
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "TAF EFKE 020532Z 0206/0215 05005KT 9999 -SHRA BKN004 BECMG" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "     0206/0208 FEW005 BKN020 TEMPO 0206/0215 4000 SHRA" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
@@ -221,8 +217,7 @@ public class TAFBulletinTACSerializationTest {
         final Optional<String> tacBulletin = tacResult.getConvertedMessage();
         assertTrue(tacBulletin.isPresent());
         assertEquals(//
-                CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
-                        + "FTFI33 EFPP 020500"//
+                "FTFI33 EFPP 020500"//
                         + CARRIAGE_RETURN.getContent() + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "TAF EFKE 020532Z 0206/0312 05005KT 9999 -SHRA BKN004 BECMG" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//
                         + "     0206/0208 FEW005 BKN020 TEMPO 0206/0215 4000 SHRA" + CARRIAGE_RETURN.getContent() + LINE_FEED.getContent()//


### PR DESCRIPTION
#102 Remove CR CR/LF from in front of generic message header  