### PR TITLE
Fmi avi messageconverter tac 103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>fi.fmi.avi.converter</groupId>
       <artifactId>fmi-avi-messageconverter</artifactId>
-      <version>5.0.1-SNAPSHOT</version>
+      <version>5.0.2-SNAPSHOT</version>
     </dependency>
 
     <!-- For JUnit tests -->

--- a/src/main/java/fi/fmi/avi/converter/tac/AbstractTACSerializer.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/AbstractTACSerializer.java
@@ -18,6 +18,7 @@ import fi.fmi.avi.converter.tac.lexer.impl.TACTokenReconstructor;
 import fi.fmi.avi.model.AviationWeatherMessage;
 import fi.fmi.avi.model.AviationWeatherMessageOrCollection;
 import fi.fmi.avi.model.CloudLayer;
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter;
 
 /**
  * Created by rinne on 07/06/17.
@@ -63,7 +64,7 @@ public abstract class AbstractTACSerializer<S extends AviationWeatherMessageOrCo
             for (final CloudLayer layer : layers) {
                 ctx.setParameter("layer", layer);
                 retval += appendToken(builder, LexemeIdentity.CLOUD, msg, clz, ctx);
-                retval += appendWhitespace(builder, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                retval += appendWhitespace(builder, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
         }
         return retval;
@@ -85,11 +86,11 @@ public abstract class AbstractTACSerializer<S extends AviationWeatherMessageOrCo
         return retval;
     }
 
-    protected int appendWhitespace(final LexemeSequenceBuilder builder, final Lexeme.MeteorologicalBulletinSpecialCharacter toAppend) {
+    protected int appendWhitespace(final LexemeSequenceBuilder builder, final MeteorologicalBulletinSpecialCharacter toAppend) {
         return appendWhitespace(builder, toAppend, 1);
     }
 
-    protected int appendWhitespace(final LexemeSequenceBuilder builder, final Lexeme.MeteorologicalBulletinSpecialCharacter toAppend, final int count) {
+    protected int appendWhitespace(final LexemeSequenceBuilder builder, final MeteorologicalBulletinSpecialCharacter toAppend, final int count) {
         for (int i = 0; i < count; i++) {
             final Lexeme l = factory.createLexeme(toAppend.getContent(), LexemeIdentity.WHITE_SPACE);
             l.setParsedValue(Lexeme.ParsedValueName.TYPE, toAppend);

--- a/src/main/java/fi/fmi/avi/converter/tac/bulletin/AbstractTACBulletinSerializer.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/bulletin/AbstractTACBulletinSerializer.java
@@ -15,6 +15,7 @@ import fi.fmi.avi.converter.tac.lexer.impl.ReconstructorContext;
 import fi.fmi.avi.model.AviationWeatherMessage;
 import fi.fmi.avi.model.AviationWeatherMessageOrCollection;
 import fi.fmi.avi.model.bulletin.MeteorologicalBulletin;
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter;
 import fi.fmi.avi.model.swx.SpaceWeatherAdvisory;
 
 public abstract class AbstractTACBulletinSerializer<S extends AviationWeatherMessage, T extends MeteorologicalBulletin<S>> extends AbstractTACSerializer<T> {
@@ -52,14 +53,14 @@ public abstract class AbstractTACBulletinSerializer<S extends AviationWeatherMes
         final T input = accepts(msg);
         final LexemeSequenceBuilder retval = this.getLexingFactory().createLexemeSequenceBuilder();
         final ReconstructorContext<T> baseCtx = new ReconstructorContext<>(input, hints);
-        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN, 2);
-        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN, 2);
+        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
         appendToken(retval, LexemeIdentity.BULLETIN_HEADING_DATA_DESIGNATORS, input, getBulletinClass(), baseCtx);
-        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         appendToken(retval, LexemeIdentity.BULLETIN_HEADING_LOCATION_INDICATOR, input, getBulletinClass(), baseCtx);
-        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         appendToken(retval, LexemeIdentity.ISSUE_TIME, input, getBulletinClass(), baseCtx);
-        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         if (appendToken(retval, LexemeIdentity.BULLETIN_HEADING_BBB_INDICATOR, input, getBulletinClass(), baseCtx) == 0) {
             retval.removeLast();
         }
@@ -80,8 +81,8 @@ public abstract class AbstractTACBulletinSerializer<S extends AviationWeatherMes
                     layout = Layout.STANDARD;
                 }
                 final int lineWrapIndent = layout.lineWrapIndent(hints);
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN, 2);
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN, 2);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
                 messageSequence = tokenizeSingleMessage(message, hints);
 
                 int charsOnRow = 0;
@@ -91,11 +92,11 @@ public abstract class AbstractTACBulletinSerializer<S extends AviationWeatherMes
                     if (layout == Layout.WHITESPACE_PASSTHROUGH || layout == Layout.ADVISORY) {
                         if (!LexemeIdentity.END_TOKEN.equals(lexeme.getIdentity())) {
                             //Append CR before an LF if the CR was not already added:
-                            if (isSpecialCharacterLexeme(lexeme, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED)) {
+                            if (isSpecialCharacterLexeme(lexeme, MeteorologicalBulletinSpecialCharacter.LINE_FEED)) {
                                 if (retval.getLast()//
-                                        .map(last -> !isSpecialCharacterLexeme(last, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN))//
+                                        .map(last -> !isSpecialCharacterLexeme(last, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN))//
                                         .orElse(false)) {
-                                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+                                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
                                 }
                                 charsOnRow = 0;
                             } else if (charsOnRow + tokenLength > MAX_ROW_LENGTH) {
@@ -119,7 +120,7 @@ public abstract class AbstractTACBulletinSerializer<S extends AviationWeatherMes
                                 charsOnRow = lineWrapIndent;
                             }
                             retval.append(lexeme);
-                            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                             charsOnRow += tokenLength + 1;
                         }
                     }
@@ -140,16 +141,16 @@ public abstract class AbstractTACBulletinSerializer<S extends AviationWeatherMes
         return SpaceWeatherAdvisory.class.isAssignableFrom(message.getClass());
     }
 
-    private boolean isSpecialCharacterLexeme(final Lexeme lexeme, final Lexeme.MeteorologicalBulletinSpecialCharacter specialCharacter) {
+    private boolean isSpecialCharacterLexeme(final Lexeme lexeme, final MeteorologicalBulletinSpecialCharacter specialCharacter) {
         return LexemeIdentity.WHITE_SPACE.equals(lexeme.getIdentity()) //
                 && lexeme.getParsedValues().containsKey(Lexeme.ParsedValueName.TYPE) //
-                && lexeme.getParsedValue(Lexeme.ParsedValueName.TYPE, Lexeme.MeteorologicalBulletinSpecialCharacter.class).equals(specialCharacter);
+                && lexeme.getParsedValue(Lexeme.ParsedValueName.TYPE, MeteorologicalBulletinSpecialCharacter.class).equals(specialCharacter);
     }
 
     private void appendLineWrap(final LexemeSequenceBuilder builder, final int indentLength) {
-        appendWhitespace(builder, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
-        appendWhitespace(builder, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
-        appendWhitespace(builder, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE, indentLength);
+        appendWhitespace(builder, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+        appendWhitespace(builder, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+        appendWhitespace(builder, MeteorologicalBulletinSpecialCharacter.SPACE, indentLength);
     }
 
     private enum Layout {

--- a/src/main/java/fi/fmi/avi/converter/tac/lexer/Lexeme.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/lexer/Lexeme.java
@@ -617,50 +617,6 @@ public interface Lexeme {
         SEQUENCE_NUMBER
     }
 
-    enum MeteorologicalBulletinSpecialCharacter {
-        START_OF_HEADING('\u0001'),
-        START_OF_TEXT('\u0002'),
-        END_OF_TEXT('\u0003'),
-        END_OF_TRANSMISSION('\u0004'),
-        ACKNOWLEDGE('\u0006'),
-        HORIZONTAL_TAB('\u0009'),
-        LINE_FEED('\n'),
-        VERTICAL_TAB('\u000B'),
-        FORM_FEED('\u000C'),
-        CARRIAGE_RETURN('\r'),
-        DATA_LINK_ESCAPE('\u0010'),
-        DEVICE_LINK_CONTROL_1('\u0011'),
-        DEVICE_LINK_CONTROL_2('\u0012'),
-        NEGATIVE_ACKNOWLEDGE('\u0015'),
-        SYNCHRONOUS_IDLE('\u0016'),
-        END_OF_TRANSMISSION_BLOCK('\u0017'),
-        ESCAPE('\u001B'),
-        FILE_SEPARATOR('\u001C'),
-        GROUP_SEPARATOR('\u001D'),
-        RECORD_SEPARATOR('\u001E'),
-        DELETE('\u007F'),
-        SPACE('\u0020');
-
-        private final char content;
-
-        MeteorologicalBulletinSpecialCharacter(final char content) {
-            this.content = content;
-        }
-
-        public static MeteorologicalBulletinSpecialCharacter fromChar(final char c) {
-            for (final MeteorologicalBulletinSpecialCharacter m : MeteorologicalBulletinSpecialCharacter.values()) {
-                if (m.getContent().equals(Character.toString(c))) {
-                    return m;
-                }
-            }
-            return null;
-        }
-
-        public String getContent() {
-            return String.valueOf(this.content);
-        }
-    }
-
     /**
      * Lambda function interface to use with
      * {@link #findNext(LexemeIdentity, Consumer, LexemeParsingNotifyer)}

--- a/src/main/java/fi/fmi/avi/converter/tac/lexer/impl/LexingFactoryImpl.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/lexer/impl/LexingFactoryImpl.java
@@ -20,6 +20,7 @@ import fi.fmi.avi.converter.tac.lexer.LexemeSequenceBuilder;
 import fi.fmi.avi.converter.tac.lexer.LexemeVisitor;
 import fi.fmi.avi.converter.tac.lexer.LexingFactory;
 import fi.fmi.avi.model.MessageType;
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter;
 
 /**
  * Default LexingFactory implementation.
@@ -27,8 +28,8 @@ import fi.fmi.avi.model.MessageType;
 
 public class LexingFactoryImpl implements LexingFactory {
 
-    private static final String TAC_DELIMS = Arrays.stream(Lexeme.MeteorologicalBulletinSpecialCharacter.values())
-            .map(Lexeme.MeteorologicalBulletinSpecialCharacter::getContent)
+    private static final String TAC_DELIMS = Arrays.stream(MeteorologicalBulletinSpecialCharacter.values())
+            .map(MeteorologicalBulletinSpecialCharacter::getContent)
             .collect(StringBuilder::new, StringBuilder::append, StringBuilder::append)
             .append("=")
             .toString();
@@ -98,7 +99,7 @@ public class LexingFactoryImpl implements LexingFactory {
             final Lexeme artificialStartToken = this.startTokens.get(toMessageType(hints.get(ConversionHints.KEY_MESSAGE_TYPE)));
             if (artificialStartToken != null) {
                 if (!input.startsWith(artificialStartToken.getTACToken() + " ") && !input.startsWith(artificialStartToken.getTACToken() + "\n")) {
-                    result.addAsFirst(new LexemeImpl(this, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE));
+                    result.addAsFirst(new LexemeImpl(this, MeteorologicalBulletinSpecialCharacter.SPACE));
                     result.addAsFirst(artificialStartToken);
                 }
             }
@@ -377,7 +378,7 @@ public class LexingFactoryImpl implements LexingFactory {
                     final String s = st.nextToken();
                     start = tac.indexOf(s, start);
                     //Special chars or space:
-                    final Lexeme.MeteorologicalBulletinSpecialCharacter specialCharacter = Lexeme.MeteorologicalBulletinSpecialCharacter.fromChar(s.charAt(0));
+                    final MeteorologicalBulletinSpecialCharacter specialCharacter = MeteorologicalBulletinSpecialCharacter.fromChar(s.charAt(0));
                     if (s.length() == 1 && specialCharacter != null) {
                         final LexemeImpl l = new LexemeImpl(this.factory, s, LexemeIdentity.WHITE_SPACE);
                         l.setStartIndex(start);

--- a/src/main/java/fi/fmi/avi/converter/tac/lexer/impl/token/PolygonCoordinatePair.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/lexer/impl/token/PolygonCoordinatePair.java
@@ -22,6 +22,7 @@ import fi.fmi.avi.model.AviationWeatherMessageOrCollection;
 import fi.fmi.avi.model.CoordinateReferenceSystem;
 import fi.fmi.avi.model.Geometry;
 import fi.fmi.avi.model.PolygonGeometry;
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter;
 import fi.fmi.avi.model.swx.AirspaceVolume;
 import fi.fmi.avi.model.swx.SpaceWeatherAdvisory;
 import fi.fmi.avi.model.swx.SpaceWeatherAdvisoryAnalysis;
@@ -132,13 +133,13 @@ public class PolygonCoordinatePair extends RegexMatchingLexemeVisitor {
                                                 lonBuilder.append(String.format("%02d", lonDecimalPart.abs().multiply(BigDecimal.valueOf(100d)).intValue()));
                                             }
                                             retval.add(this.createLexeme(
-                                                    latBuilder.toString() + Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE.getContent()
+                                                    latBuilder.toString() + MeteorologicalBulletinSpecialCharacter.SPACE.getContent()
                                                             + lonBuilder.toString(), LexemeIdentity.POLYGON_COORDINATE_PAIR));
                                             if (coordPairIndex < coords.size() - 2) {
-                                                retval.add(this.createLexeme(Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE.getContent(),
+                                                retval.add(this.createLexeme(MeteorologicalBulletinSpecialCharacter.SPACE.getContent(),
                                                         LexemeIdentity.WHITE_SPACE));
                                                 retval.add(this.createLexeme("-", LexemeIdentity.POLYGON_COORDINATE_PAIR_SEPARATOR));
-                                                retval.add(this.createLexeme(Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE.getContent(),
+                                                retval.add(this.createLexeme(MeteorologicalBulletinSpecialCharacter.SPACE.getContent(),
                                                         LexemeIdentity.WHITE_SPACE));
                                             }
                                         } else {

--- a/src/main/java/fi/fmi/avi/converter/tac/metar/METARTACSerializerBase.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/metar/METARTACSerializerBase.java
@@ -16,6 +16,7 @@ import fi.fmi.avi.converter.tac.lexer.impl.ReconstructorContext;
 import fi.fmi.avi.model.AviationWeatherMessageOrCollection;
 import fi.fmi.avi.model.CloudForecast;
 import fi.fmi.avi.model.Weather;
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter;
 import fi.fmi.avi.model.metar.MeteorologicalTerminalAirReport;
 import fi.fmi.avi.model.metar.ObservedClouds;
 import fi.fmi.avi.model.metar.RunwayState;
@@ -56,19 +57,19 @@ public abstract class METARTACSerializerBase<T extends MeteorologicalTerminalAir
         final ReconstructorContext<T> baseCtx = new ReconstructorContext<>(input, hints);
         final LexemeSequenceBuilder retval = this.getLexingFactory().createLexemeSequenceBuilder();
         appendToken(retval, getStartTokenIdentity(), input, getMessageClass(), baseCtx);
-        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         if (appendToken(retval, LexemeIdentity.CORRECTION, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.AERODROME_DESIGNATOR, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.ISSUE_TIME, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
 
         if (appendToken(retval, LexemeIdentity.ROUTINE_DELAYED_OBSERVATION, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
 
         if (appendToken(retval, LexemeIdentity.NIL, input, getMessageClass(), baseCtx) > 0) {
@@ -77,105 +78,105 @@ public abstract class METARTACSerializerBase<T extends MeteorologicalTerminalAir
         }
 
         if (appendToken(retval, LexemeIdentity.AUTOMATED, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.SURFACE_WIND, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.VARIABLE_WIND_DIRECTION, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.CAVOK, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.HORIZONTAL_VISIBILITY, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (input.getRunwayVisualRanges().isPresent()) {
             for (final RunwayVisualRange range : input.getRunwayVisualRanges().get()) {
                 appendToken(retval, LexemeIdentity.RUNWAY_VISUAL_RANGE, input, getMessageClass(), baseCtx.copyWithParameter("rvr", range));
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
         }
         if (input.getPresentWeather().isPresent()) {
             for (final Weather weather : input.getPresentWeather().get()) {
                 appendToken(retval, LexemeIdentity.WEATHER, input, getMessageClass(), baseCtx.copyWithParameter("weather", weather));
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
         }
         final Optional<ObservedClouds> obsClouds = input.getClouds();
         if (obsClouds.isPresent()) {
             if (obsClouds.get().getVerticalVisibility().isPresent() || obsClouds.get().isVerticalVisibilityUnobservableByAutoSystem()) {
                 this.appendToken(retval, LexemeIdentity.CLOUD, input, getMessageClass(), baseCtx.copyWithParameter("verticalVisibility", Boolean.TRUE));
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             } else if (obsClouds.get().getLayers().isPresent()) {
                 this.appendCloudLayers(retval, input, getMessageClass(), obsClouds.get().getLayers().get(), baseCtx);
             } else if (obsClouds.get().isNoCloudsDetectedByAutoSystem() || obsClouds.get().isNoSignificantCloud()) {
                 this.appendToken(retval, LexemeIdentity.CLOUD, input, getMessageClass(), baseCtx);
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
         }
         if (appendToken(retval, LexemeIdentity.AIR_DEWPOINT_TEMPERATURE, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.AIR_PRESSURE_QNH, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (input.getRecentWeather().isPresent()) {
             for (final Weather weather : input.getRecentWeather().get()) {
                 appendToken(retval, LexemeIdentity.RECENT_WEATHER, input, getMessageClass(), baseCtx.copyWithParameter("weather", weather));
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
         }
         if (appendToken(retval, LexemeIdentity.WIND_SHEAR, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.SEA_STATE, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (input.getRunwayStates().isPresent()) {
             for (final RunwayState state : input.getRunwayStates().get()) {
                 appendToken(retval, LexemeIdentity.RUNWAY_STATE, input, getMessageClass(), baseCtx.copyWithParameter("state", state));
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
         }
         if (appendToken(retval, LexemeIdentity.SNOW_CLOSURE, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.NO_SIGNIFICANT_WEATHER, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.COLOR_CODE, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.NO_SIGNIFICANT_CHANGES, input, getMessageClass(), baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (input.getTrends().isPresent()) {
             for (final TrendForecast trend : input.getTrends().get()) {
                 final ReconstructorContext<T> trendCtx = baseCtx.copyWithParameter("trend", trend);
                 if (appendToken(retval, LexemeIdentity.TREND_CHANGE_INDICATOR, input, getMessageClass(), trendCtx) > 0) {
-                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                 }
                 if (appendToken(retval, LexemeIdentity.TREND_TIME_GROUP, input, getMessageClass(), trendCtx) > 0) {
-                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                 }
                 if (appendToken(retval, LexemeIdentity.SURFACE_WIND, input, getMessageClass(), trendCtx) > 0) {
-                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                 }
                 if (appendToken(retval, LexemeIdentity.CAVOK, input, getMessageClass(), trendCtx) > 0) {
-                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                 }
                 if (appendToken(retval, LexemeIdentity.NO_SIGNIFICANT_WEATHER, input, getMessageClass(), trendCtx) > 0) {
-                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                 }
                 if (appendToken(retval, LexemeIdentity.HORIZONTAL_VISIBILITY, input, getMessageClass(), trendCtx) > 0) {
-                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                 }
                 if (trend.getForecastWeather().isPresent()) {
                     for (final Weather weather : trend.getForecastWeather().get()) {
                         appendToken(retval, LexemeIdentity.WEATHER, input, getMessageClass(), trendCtx.copyWithParameter("weather", weather));
-                        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                     }
                 }
 
@@ -184,25 +185,25 @@ public abstract class METARTACSerializerBase<T extends MeteorologicalTerminalAir
                     if (clouds.get().getVerticalVisibility().isPresent()) {
                         this.appendToken(retval, LexemeIdentity.CLOUD, input, getMessageClass(),
                                 trendCtx.copyWithParameter("verticalVisibility", Boolean.TRUE));
-                        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                     } else if (clouds.get().isNoSignificantCloud()) {
                         this.appendToken(retval, LexemeIdentity.CLOUD, input, getMessageClass(), trendCtx);
-                        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                     } else if (clouds.get().getLayers().isPresent()) {
                         this.appendCloudLayers(retval, input, getMessageClass(), clouds.get().getLayers().get(), trendCtx);
                     }
                 }
                 if (appendToken(retval, LexemeIdentity.COLOR_CODE, input, getMessageClass(), trendCtx) > 0) {
-                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                 }
             }
         }
         if (input.getRemarks().isPresent()) {
             appendToken(retval, LexemeIdentity.REMARKS_START, input, getMessageClass(), baseCtx);
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             for (final String remark : input.getRemarks().get()) {
                 this.appendToken(retval, LexemeIdentity.REMARK, input, getMessageClass(), baseCtx.copyWithParameter("remark", remark));
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
         }
         retval.removeLast();

--- a/src/main/java/fi/fmi/avi/converter/tac/swx/SWXTACSerializer.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/swx/SWXTACSerializer.java
@@ -11,6 +11,7 @@ import fi.fmi.avi.converter.tac.lexer.LexemeSequenceBuilder;
 import fi.fmi.avi.converter.tac.lexer.SerializingException;
 import fi.fmi.avi.converter.tac.lexer.impl.ReconstructorContext;
 import fi.fmi.avi.model.AviationWeatherMessageOrCollection;
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter;
 import fi.fmi.avi.model.swx.SpaceWeatherAdvisory;
 
 public class SWXTACSerializer extends AbstractTACSerializer<SpaceWeatherAdvisory> {
@@ -48,50 +49,50 @@ public class SWXTACSerializer extends AbstractTACSerializer<SpaceWeatherAdvisory
         final ReconstructorContext<SpaceWeatherAdvisory> baseCtx = new ReconstructorContext<>(input, hints);
 
         if (appendToken(retval, LexemeIdentity.SPACE_WEATHER_ADVISORY_START, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
         }
         if (appendToken(retval, LexemeIdentity.ADVISORY_STATUS_LABEL, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
             appendSpacePadding(retval, labelColumnWidth);
         }
         if (appendToken(retval, LexemeIdentity.ADVISORY_STATUS, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
         }
         if (appendToken(retval, LexemeIdentity.DTG_ISSUE_TIME_LABEL, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
             appendSpacePadding(retval, labelColumnWidth);
         }
         if (appendToken(retval, LexemeIdentity.ISSUE_TIME, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
         }
         if (appendToken(retval, LexemeIdentity.SWX_CENTRE_LABEL, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
             appendSpacePadding(retval, labelColumnWidth);
         }
         if (appendToken(retval, LexemeIdentity.SWX_CENTRE, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
         }
         if (appendToken(retval, LexemeIdentity.ADVISORY_NUMBER_LABEL, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
             appendSpacePadding(retval, labelColumnWidth);
         }
         if (appendToken(retval, LexemeIdentity.ADVISORY_NUMBER, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
         }
         if (appendToken(retval, LexemeIdentity.REPLACE_ADVISORY_NUMBER_LABEL, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
             appendSpacePadding(retval, labelColumnWidth);
         }
         if (appendToken(retval, LexemeIdentity.REPLACE_ADVISORY_NUMBER, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
         }
         if (appendToken(retval, LexemeIdentity.SWX_EFFECT_LABEL, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
             appendSpacePadding(retval, labelColumnWidth);
         }
         if (appendToken(retval, LexemeIdentity.SWX_EFFECT, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
         }
         for (int i = 0; i < input.getAnalyses().size(); i++) {
             final ReconstructorContext<SpaceWeatherAdvisory> analysisContext = baseCtx.copyWithParameter("analysisIndex", i);
@@ -101,42 +102,42 @@ public class SWXTACSerializer extends AbstractTACSerializer<SpaceWeatherAdvisory
             }
 
             if (appendToken(retval, LexemeIdentity.ADVISORY_PHENOMENA_TIME_GROUP, input, SpaceWeatherAdvisory.class, analysisContext) > 0) {
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
 
             if (appendToken(retval, LexemeIdentity.SWX_NOT_EXPECTED, input, SpaceWeatherAdvisory.class, analysisContext) > 0) {
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
             if (appendToken(retval, LexemeIdentity.SWX_NOT_AVAILABLE, input, SpaceWeatherAdvisory.class, analysisContext) > 0) {
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
             if (appendToken(retval, LexemeIdentity.SWX_PHENOMENON_PRESET_LOCATION, input, SpaceWeatherAdvisory.class, analysisContext) > 0) {
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
 
             if (appendToken(retval, LexemeIdentity.SWX_PHENOMENON_LONGITUDE_LIMIT, input, SpaceWeatherAdvisory.class, analysisContext) > 0) {
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
 
             if (appendToken(retval, LexemeIdentity.SWX_PHENOMENON_VERTICAL_LIMIT, input, SpaceWeatherAdvisory.class, analysisContext) > 0) {
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
 
             if (appendToken(retval, LexemeIdentity.POLYGON_COORDINATE_PAIR, input, SpaceWeatherAdvisory.class, analysisContext) > 0) {
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
             if (retval.getLast().isPresent() && LexemeIdentity.WHITE_SPACE.equals(retval.getLast().get().getIdentity())) {
                 retval.removeLast(); // last whitespace removed
             }
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
         }
         appendToken(retval, LexemeIdentity.REMARKS_START, input, SpaceWeatherAdvisory.class, baseCtx);
         appendSpacePadding(retval, labelColumnWidth);
         if (input.getRemarks().isPresent()) {
             for (final String remark : input.getRemarks().get()) {
                 this.appendToken(retval, LexemeIdentity.REMARK, input, SpaceWeatherAdvisory.class, baseCtx.copyWithParameter("remark", remark));
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
             if (retval.getLast().isPresent() && LexemeIdentity.WHITE_SPACE.equals(retval.getLast().get().getIdentity())) {
                 retval.removeLast(); // last whitespace removed
@@ -144,8 +145,8 @@ public class SWXTACSerializer extends AbstractTACSerializer<SpaceWeatherAdvisory
         } else {
             this.appendToken(retval, LexemeIdentity.REMARK, input, SpaceWeatherAdvisory.class, baseCtx.copyWithParameter("remark", "NIL"));
         }
-        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
-        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
         if (appendToken(retval, LexemeIdentity.NEXT_ADVISORY_LABEL, input, SpaceWeatherAdvisory.class, baseCtx) > 0) {
             appendSpacePadding(retval, labelColumnWidth);
         }
@@ -158,7 +159,7 @@ public class SWXTACSerializer extends AbstractTACSerializer<SpaceWeatherAdvisory
         if (labelSize > 0) {
             if (builder.getLast().isPresent()) {
                 final int whiteSpace = labelSize - builder.getLast().get().getTACToken().length();
-                appendWhitespace(builder, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE, whiteSpace);
+                appendWhitespace(builder, MeteorologicalBulletinSpecialCharacter.SPACE, whiteSpace);
             }
         }
     }

--- a/src/main/java/fi/fmi/avi/converter/tac/taf/TAFTACSerializer.java
+++ b/src/main/java/fi/fmi/avi/converter/tac/taf/TAFTACSerializer.java
@@ -16,6 +16,7 @@ import fi.fmi.avi.converter.tac.lexer.impl.ReconstructorContext;
 import fi.fmi.avi.model.AviationWeatherMessageOrCollection;
 import fi.fmi.avi.model.CloudForecast;
 import fi.fmi.avi.model.Weather;
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter;
 import fi.fmi.avi.model.taf.TAF;
 import fi.fmi.avi.model.taf.TAFAirTemperatureForecast;
 import fi.fmi.avi.model.taf.TAFBaseForecast;
@@ -52,27 +53,27 @@ public class TAFTACSerializer extends AbstractTACSerializer<TAF> {
         final LexemeSequenceBuilder retval = this.getLexingFactory().createLexemeSequenceBuilder();
         final ReconstructorContext<TAF> baseCtx = new ReconstructorContext<>(input, hints);
         appendToken(retval, LexemeIdentity.TAF_START, input, TAF.class, baseCtx);
-        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         if (appendToken(retval, LexemeIdentity.AMENDMENT, input, TAF.class, baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.CORRECTION, input, TAF.class, baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.AERODROME_DESIGNATOR, input, TAF.class, baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         if (appendToken(retval, LexemeIdentity.ISSUE_TIME, input, TAF.class, baseCtx) > 0) {
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
 
         if (!input.isMissingMessage()) {
             if (appendToken(retval, LexemeIdentity.VALID_TIME, input, TAF.class, baseCtx) > 0) {
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
 
             if (appendToken(retval, LexemeIdentity.CANCELLATION, input, TAF.class, baseCtx) > 0) {
-                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
             if (!input.isCancelMessage()) {
                 final Optional<TAFBaseForecast> baseFct = input.getBaseForecast();
@@ -81,18 +82,18 @@ public class TAFTACSerializer extends AbstractTACSerializer<TAF> {
                 }
                 final ReconstructorContext<TAF> baseFctCtx = baseCtx.copyWithParameter("forecast", baseFct.get());
                 if (appendToken(retval, LexemeIdentity.SURFACE_WIND, input, TAF.class, baseFctCtx) > 0) {
-                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                 }
                 if (appendToken(retval, LexemeIdentity.CAVOK, input, TAF.class, baseFctCtx) > 0) {
-                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                 }
                 if (appendToken(retval, LexemeIdentity.HORIZONTAL_VISIBILITY, input, TAF.class, baseFctCtx) > 0) {
-                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                 }
                 if (baseFct.get().getForecastWeather().isPresent()) {
                     for (final Weather weather : baseFct.get().getForecastWeather().get()) {
                         appendToken(retval, LexemeIdentity.WEATHER, input, TAF.class, baseFctCtx.copyWithParameter("weather", weather));
-                        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                     }
                 }
                 final Optional<CloudForecast> clouds = baseFct.get().getCloud();
@@ -104,9 +105,9 @@ public class TAFTACSerializer extends AbstractTACSerializer<TAF> {
                     for (final TAFAirTemperatureForecast tempFct : baseFct.get().getTemperatures().get()) {
                         final ReconstructorContext<TAF> tempCtx = baseFctCtx.copyWithParameter("temp", tempFct);
                         appendToken(retval, LexemeIdentity.MAX_TEMPERATURE, input, TAF.class, tempCtx);
-                        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                         appendToken(retval, LexemeIdentity.MIN_TEMPERATURE, input, TAF.class, tempCtx);
-                        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                     }
                 }
 
@@ -114,30 +115,30 @@ public class TAFTACSerializer extends AbstractTACSerializer<TAF> {
                     for (final TAFChangeForecast changeFct : input.getChangeForecasts().get()) {
                         final ReconstructorContext<TAF> changeFctCtx = baseCtx.copyWithParameter("forecast", changeFct);
                         retval.removeLast(); //last whitespace
-                        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
-                        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED);
+                        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN);
+                        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.LINE_FEED);
                         if (appendToken(retval, LexemeIdentity.TAF_FORECAST_CHANGE_INDICATOR, input, TAF.class, changeFctCtx) > 0) {
-                            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                         }
                         if (appendToken(retval, LexemeIdentity.TAF_CHANGE_FORECAST_TIME_GROUP, input, TAF.class, changeFctCtx) > 0) {
-                            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                         }
                         if (appendToken(retval, LexemeIdentity.SURFACE_WIND, input, TAF.class, changeFctCtx) > 0) {
-                            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                         }
                         if (appendToken(retval, LexemeIdentity.CAVOK, input, TAF.class, changeFctCtx) > 0) {
-                            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                         }
                         if (appendToken(retval, LexemeIdentity.HORIZONTAL_VISIBILITY, input, TAF.class, changeFctCtx) > 0) {
-                            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                         }
                         if (appendToken(retval, LexemeIdentity.NO_SIGNIFICANT_WEATHER, input, TAF.class, changeFctCtx) > 0) {
-                            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                         }
                         if (changeFct.getForecastWeather().isPresent()) {
                             for (final Weather weather : changeFct.getForecastWeather().get()) {
                                 appendToken(retval, LexemeIdentity.WEATHER, input, TAF.class, changeFctCtx.copyWithParameter("weather", weather));
-                                appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                                appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                             }
                         }
                         if (changeFct.getCloud().isPresent()) {
@@ -147,16 +148,16 @@ public class TAFTACSerializer extends AbstractTACSerializer<TAF> {
                 }
                 if (input.getRemarks().isPresent()) {
                     appendToken(retval, LexemeIdentity.REMARKS_START, input, TAF.class, baseCtx);
-                    appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                    appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                     for (final String remark : input.getRemarks().get()) {
                         this.appendToken(retval, LexemeIdentity.REMARK, input, TAF.class, baseCtx.copyWithParameter("remark", remark));
-                        appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                        appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
                     }
                 }
             }
         } else {
             appendToken(retval, LexemeIdentity.NIL, input, TAF.class, baseCtx);
-            appendWhitespace(retval, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+            appendWhitespace(retval, MeteorologicalBulletinSpecialCharacter.SPACE);
         }
         retval.removeLast();
         appendToken(retval, LexemeIdentity.END_TOKEN, input, TAF.class, baseCtx);
@@ -168,12 +169,12 @@ public class TAFTACSerializer extends AbstractTACSerializer<TAF> {
         if (clouds != null) {
             if (clouds.getVerticalVisibility().isPresent()) {
                 this.appendToken(builder, LexemeIdentity.CLOUD, input, TAF.class, ctx.copyWithParameter("verticalVisibility", Boolean.TRUE));
-                appendWhitespace(builder, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(builder, MeteorologicalBulletinSpecialCharacter.SPACE);
             } else if (clouds.getLayers().isPresent()) {
                 this.appendCloudLayers(builder, input, TAF.class, clouds.getLayers().get(), ctx);
             } else if (clouds.isNoSignificantCloud()) {
                 this.appendToken(builder, LexemeIdentity.CLOUD, input, TAF.class, ctx);
-                appendWhitespace(builder, Lexeme.MeteorologicalBulletinSpecialCharacter.SPACE);
+                appendWhitespace(builder, MeteorologicalBulletinSpecialCharacter.SPACE);
             }
         }
     }

--- a/src/test/java/fi/fmi/avi/converter/tac/bulletin/GenericMeteorologicalBulletinTACSerializerTest.java
+++ b/src/test/java/fi/fmi/avi/converter/tac/bulletin/GenericMeteorologicalBulletinTACSerializerTest.java
@@ -1,7 +1,7 @@
 package fi.fmi.avi.converter.tac.bulletin;
 
-import static fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
-import static fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
 import static fi.fmi.avi.model.bulletin.DataTypeDesignatorT1.UPPER_AIR_DATA;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/fi/fmi/avi/converter/tac/sigmet/SIGMETBulletinTACSerializationTest.java
+++ b/src/test/java/fi/fmi/avi/converter/tac/sigmet/SIGMETBulletinTACSerializationTest.java
@@ -1,7 +1,7 @@
 package fi.fmi.avi.converter.tac.sigmet;
 
-import static fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
-import static fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/fi/fmi/avi/converter/tac/swx/SWXBulletinTACSerializationTest.java
+++ b/src/test/java/fi/fmi/avi/converter/tac/swx/SWXBulletinTACSerializationTest.java
@@ -1,7 +1,7 @@
 package fi.fmi.avi.converter.tac.swx;
 
-import static fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
-import static fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 

--- a/src/test/java/fi/fmi/avi/converter/tac/swx/SWXTACSerializerTest.java
+++ b/src/test/java/fi/fmi/avi/converter/tac/swx/SWXTACSerializerTest.java
@@ -1,7 +1,7 @@
 package fi.fmi.avi.converter.tac.swx;
 
-import static fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
-import static fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/fi/fmi/avi/converter/tac/taf/TAFBulletinTACSerializationTest.java
+++ b/src/test/java/fi/fmi/avi/converter/tac/taf/TAFBulletinTACSerializationTest.java
@@ -1,7 +1,7 @@
 package fi.fmi.avi.converter.tac.taf;
 
-import static fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
-import static fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 


### PR DESCRIPTION
issue #103 

Remove fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter.
Replace references to fi.fmi.avi.converter.tac.lexer.Lexeme.MeteorologicalBulletinSpecialCharacter with references to fmi-avi-messageconverter repository's fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.
Update fmi-avi-messageconverter version number in pom.